### PR TITLE
Fix bug where DB does not refresh if changes are only made to strings.

### DIFF
--- a/bibtexbrowser.php
+++ b/bibtexbrowser.php
@@ -3736,7 +3736,7 @@ class BibDataBase {
         $this->addEntry($b);
       }
       // update entry
-      else if (isset($this->bibdb[$b->getKey()]) && ($b->getText() !== $this->bibdb[$b->getKey()]->getText())) {
+      else if (isset($this->bibdb[$b->getKey()]) && ($b->toHTML() !== $this->bibdb[$b->getKey()]->toHTML())) {
         //echo 'replacing...<br/>';
         $this->bibdb[$b->getKey()] = $b;
       }


### PR DESCRIPTION
Fix #1 

The problem turned out to be in how bibtexbrowser determines if a bibtex entry was updated or not.  It only looks at the bibtex entry itself and not any strings it might depend on.  The simple fix is to have it compare the generated HTML, which would capture all string dependencies.